### PR TITLE
Added Gwenview to install. No image viewer was added to install, so I added Gwenview.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@
 - `Swaylock-effects` - for swaylock effects
 - `Dunst` - for notifications
 - `Grimblast` - for screenshot
-- `Brightnessctl`  - for monitor and keyboard
-- `brightness` - not needed for desktop
-- `Swayimg` - for image viewer 
+- `Gwenview` - for image viewer 
 - `Pamixer` - for volume control notification
 - `Lxappearance` - for gtk themes
 - `Nwg-look` - for gtk themes

--- a/install-scripts/4-hypr_pkgs.sh
+++ b/install-scripts/4-hypr_pkgs.sh
@@ -30,6 +30,7 @@ hypr_package=(
   dolphin
   git
   grim
+  gwenview
   jq
   kitty
   kvantum


### PR DESCRIPTION
It is optional. **Swayimg** or other image viewer can be added.